### PR TITLE
update doc

### DIFF
--- a/mkdocs/docs/urwahl3000.md
+++ b/mkdocs/docs/urwahl3000.md
@@ -6,8 +6,9 @@ Wir versuchen, den Umzug von Urwahl3000 so einfach wie möglich zu gesalten.
 Wenn Du *sunflower* aktivierst, werden die Widgets in den beiden Seitenleisten von Urwahl3000 automatisch importiert.
 
 ## Menüs
-Das Hauptmenü und das Footermenü werden automatisch erkannt. Lediglich das Menü an der oberen Seitenleiste musst Du neu platzieren.Gehe dazu auf *Design -> Menüs* und dann auf *Positionen verwalten*, (wp-admin/nav-menus.php?action=locations).
-Wenn Du bisher Termine verwendet hast, musst Du diesen Punkt im Menü ersetzen. Mehr dazu unter [Termine](events.md#ubersichtsseite-im-menu-einfugen)
+Das Hauptmenü und das Footermenü werden automatisch erkannt. Lediglich das Menü an der oberen Seitenleiste musst Du neu platzieren. Gehe dazu auf *Design -> Menüs* und dann auf *Positionen verwalten*, (wp-admin/nav-menus.php?action=locations).
+Wenn Du bisher Termine verwendet hast, musst Du diesen Punkt im Menü ersetzen. Mehr dazu unter [Termine](events.md#ubersichtsseite-im-menu-einfugen).
+Außerdem sind bei verzweigten Menüstrukturen die jeweiligen Haupteinträge nicht mehr als Links verwendbar, und müssen daher gegebenenfalls angepasst werden.
 
 ## Startseite
 Du kannst die bisherige Startseite so lassen oder eine neue, besonders schöne Startseite anlegen. Mehr dazu gibt es


### PR DESCRIPTION
In Urwahl3000 war es möglich, auch die Hauptmenüeinträge als Link zu verwenden. Der nav handler in sunflower unterstützt dies nicht. Das sollte in der Dokumentation zum Umstieg erwähnt werden, da man in diesem Fall das Menü händisch anpassen muss.