### PR TITLE
Bugfix thumbnail size

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -158,7 +158,7 @@ if ( ! function_exists( 'sunflower_post_thumbnail' ) ) :
 				$classes = array('post-thumbnail' );
 
 				the_post_thumbnail(
-					'medium-large',
+					'medium_large',
 					array(
 						'alt' => the_title_attribute(
 							array(


### PR DESCRIPTION
Referencing https://codex.wordpress.org/Post_Thumbnails the correct value of the parameter size (function the_post_thumbnail) has to be 'medium_large', not 'medium-large'.