### PR TITLE
Deaktiviere API-Zugriff auf users, wenn Benutzer verborgen sind

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -25,6 +25,7 @@ require_once('functions/icalimport.php');
 require_once('functions/pictureimport.php');
 require_once('functions/emailscrambler.php');
 require_once('functions/contact-form.php');
+require_once('functions/api.php');
 require_once('functions/childtheme.php');
 
 

--- a/functions/api.php
+++ b/functions/api.php
@@ -1,0 +1,11 @@
+<?php
+
+add_filter( 'rest_endpoints', function( $endpoints ){
+    if ( isset( $endpoints['/wp/v2/users'] ) && !get_sunflower_setting('sunflower_show_author') ) {
+        unset( $endpoints['/wp/v2/users'] );
+    }
+    if ( isset( $endpoints['/wp/v2/users/(?P<id>[\d]+)'] ) && !get_sunflower_setting('sunflower_show_author') ) {
+        unset( $endpoints['/wp/v2/users/(?P<id>[\d]+)'] );
+    }
+    return $endpoints;
+});


### PR DESCRIPTION
Mittels REST-API von WordPress kann eine Liste der User ausgegeben werden. In den Einstellungen von sunflower kann die Anzeige des Benutzernamens unterbunden werden, mit diesem PR wird, sofern diese Funktion aktiviert ist, auch die Anzeige über die API unterbunden.