### PR TITLE
Add frosted photo credit overlay to hero cover block #1231 

### DIFF
--- a/functions/media.php
+++ b/functions/media.php
@@ -179,13 +179,40 @@ add_action( 'admin_enqueue_scripts', 'sunflower_enqueue_media_script' );
  */
 function sunflower_add_creator_to_image_block( $block_content, $block ) {
 
-	if ( isset( $block['blockName'] ) && ( 'core/image' === $block['blockName'] || 'core/media-text' === $block['blockName'] ) ) {
+	$block_name      = $block['blockName'] ?? '';
+	$creator_setting = sunflower_get_setting( 'sunflower_media_creator' );
+	$creator_setting = $creator_setting ? $creator_setting : 'optional';
 
-		$sunflower_media_creator_settings = sunflower_get_setting( 'sunflower_media_creator' ) ? sunflower_get_setting( 'sunflower_media_creator' ) : 'optional';
+	if ( 'disabled' === $creator_setting ) {
+		return $block_content;
+	}
 
-		if ( 'disabled' === $sunflower_media_creator_settings ) {
-			return $block_content;
+	if ( 'core/cover' === $block_name && str_contains( $block['attrs']['className'] ?? '', 'is-style-sunflower-hero' ) ) {
+
+		$attachment_id = (int) ( $block['attrs']['id'] ?? 0 );
+
+		if ( $attachment_id ) {
+			$creator = get_post_meta( $attachment_id, '_media_creator', true );
+
+			if ( ! empty( $creator ) ) {
+				$block_content = preg_replace(
+					'/(<\/div>\s*)$/s',
+					'<p class="sunflower-photo-credit">' . wp_kses_post( $creator ) . '</p>$1',
+					$block_content
+				);
+			} elseif ( 'strict' === $creator_setting ) {
+				$block_content = preg_replace(
+					'/(<div[^>]*class=")([^"]*is-style-sunflower-hero[^"]*)"/',
+					'$1$2 no-creator"',
+					$block_content
+				);
+			}
 		}
+
+		return $block_content;
+	}
+
+	if ( 'core/image' === $block_name || 'core/media-text' === $block_name ) {
 
 		$attachment_id = 0;
 		if ( isset( $block['attrs']['id'] ) ) {
@@ -215,7 +242,7 @@ function sunflower_add_creator_to_image_block( $block_content, $block ) {
 						$block_content
 					);
 				}
-			} elseif ( 'strict' === $sunflower_media_creator_settings ) {
+			} elseif ( 'strict' === $creator_setting ) {
 				// Find img tag and extend it.
 				$block_content = preg_replace(
 					'/(<img[^>]*class=")([^"]*)"/',

--- a/sass/wp-blocks/cover.scss
+++ b/sass/wp-blocks/cover.scss
@@ -103,9 +103,18 @@
 
     @include breakpoint-down(md) {
         height: fit-content !important;
-        flex-direction: column;
+        display: grid;
+        grid-template-columns: 1fr;
         min-height: 250px;
         padding: 0 !important;
+    }
+
+    .wp-block-cover__background {
+
+        @include breakpoint-down(md) {
+            grid-row: 1;
+            grid-column: 1;
+        }
     }
 
     .wp-block-cover__image-background {
@@ -120,6 +129,8 @@
             position: relative !important;
             border-radius: var(--border-radius-large) 0;
             min-height: 350px;
+            grid-row: 1;
+            grid-column: 1;
         }
     }
 
@@ -153,6 +164,8 @@
             justify-content: center;
             align-items: center;
             position: relative !important;
+            grid-row: 2;
+            grid-column: 1;
 
             h1 {
                 margin-top: -32px;
@@ -240,6 +253,42 @@
                 right: -11px;
                 transform: rotate(90deg);
             }
+        }
+    }
+
+    &.no-creator {
+
+        .wp-block-cover__image-background {
+            filter: blur(11px);
+            transition: filter 0.3s ease;
+        }
+    }
+
+    .sunflower-photo-credit {
+        position: absolute;
+        bottom: 0;
+        right: 0;
+        margin: 0;
+        color: inherit;
+        text-align: right;
+        font-size: 10px;
+        line-height: 120%;
+        padding: 2px var(--gap-small);
+        backdrop-filter: blur(25px) saturate(200%);
+        -webkit-backdrop-filter: blur(25px) saturate(200%);
+        background-color: rgba(255, 255, 255, 0.7);
+        border: 1px solid rgba(255, 255, 255, 0.15);
+        z-index: 1;
+
+        @include breakpoint-down(md) {
+            font-size: 8px;
+            position: relative;
+            bottom: auto;
+            right: auto;
+            grid-row: 1;
+            grid-column: 1;
+            align-self: end;
+            justify-self: end;
         }
     }
 }

--- a/sass/wp-blocks/cover.scss
+++ b/sass/wp-blocks/cover.scss
@@ -268,28 +268,80 @@
         position: absolute;
         bottom: 0;
         right: 0;
-        margin: 0;
+        max-width: 35%; // wraps before reaching the inner-container (max-width: 70% from left)
+        margin: 0 !important;
         color: inherit;
         text-align: right;
-        font-size: 10px;
-        line-height: 120%;
-        padding: 2px var(--gap-small);
+        font-size: 12px;
+        line-height: 1.2;
+        // Extra right padding clears the parent's border-radius corner arc.
+        padding: 4px calc(var(--gap-small) + var(--border-radius-small)) 4px var(--gap-small);
         backdrop-filter: blur(25px) saturate(200%);
         -webkit-backdrop-filter: blur(25px) saturate(200%);
         background-color: rgba(255, 255, 255, 0.7);
-        border: 1px solid rgba(255, 255, 255, 0.15);
+        border-top: 1px solid rgba(255, 255, 255, 0.15);
+        border-left: 1px solid rgba(255, 255, 255, 0.15);
+        border-radius: var(--border-radius-small) 0 0 0;
         z-index: 1;
 
+        body.formstyle-sharp & {
+            bottom: 0;
+            right: 0;
+            max-width: min(24rem, calc(100% - var(--double-grid-margin)));
+            padding: 3px var(--gap-small);
+            padding-right: var(--gap-small);
+            background-color: rgba(255, 255, 255, 0.82);
+            border-right: 1px solid rgba(255, 255, 255, 0.15);
+            border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+            border-radius: 0;
+            z-index: 21;
+        }
+
+        @include breakpoint-down(xl) {
+            max-width: 30%; // inner-container grows to 75% here
+        }
+
         @include breakpoint-down(md) {
-            font-size: 8px;
             position: relative;
             bottom: auto;
             right: auto;
+            max-width: none;
+            // On mobile, keep the credit aligned to the image grid row instead
+            // of the taller cover block.
+            border-bottom-right-radius: var(--border-radius-large);
             grid-row: 1;
             grid-column: 1;
             align-self: end;
             justify-self: end;
+
+            body.formstyle-sharp & {
+                max-width: calc(100% - var(--double-grid-margin));
+                margin: 0 !important;
+                transform: translateY(100%);
+            }
         }
+    }
+}
+
+@media (min-width: 769px) {
+
+    body.formstyle-sharp .entry-content > :first-child.wp-block-cover.is-style-sunflower-hero .sunflower-photo-credit {
+        right: calc(-1 * var(--grid-margin));
+    }
+
+    body.formstyle-sharp .entry-content > :first-child.wp-block-cover.is-style-sunflower-hero:has(.sunflower-photo-credit) .wp-block-cover__inner-container {
+        padding-bottom: calc(var(--grid-margin) + 28px) !important;
+    }
+}
+
+@include breakpoint-down(md) {
+
+    body.formstyle-sharp .entry-content > .wp-block-cover.is-style-sunflower-hero:has(.sunflower-photo-credit) .wp-block-cover__inner-container {
+        padding-top: calc(var(--double-grid-margin) + 28px) !important;
+    }
+
+    body.formstyle-sharp .entry-content > :first-child.wp-block-cover.is-style-sunflower-hero .sunflower-photo-credit {
+        margin-right: calc(-1 * var(--grid-margin)) !important;
     }
 }
 


### PR DESCRIPTION
Extends the media creator feature to core/cover blocks with the is-style-sunflower-hero style: displays a photo credit overlay when a creator is set, blurs the image in strict mode when no creator is provided. Also fixes the mobile layout of the hero block using CSS Grid to correctly stack background and content layers.

#1231 
