### PR TITLE
Automatic dark scheme as third design option

### DIFF
--- a/assets/js/auto-dark-switcher.js
+++ b/assets/js/auto-dark-switcher.js
@@ -2,20 +2,37 @@
    Sunflower – Automatisch dunkles Design
    -------------------------------------------------------------- */
 ( () => {
+	// Inhibit automatic dark mode when design switcher sets colorscheme to a value other than "auto"
+	const inhibitAutoDark = () => {
+		const raw = localStorage.getItem( 'sunflower_design' );
+		try {
+			return JSON.parse( raw ).colorscheme !== 'auto';
+		} catch ( e ) {
+			return false;
+		}
+	};
 
 	const updateAutoDark = () => {
+		if ( inhibitAutoDark() ) {
+			return;
+		}
 		const body = document.body;
-		const darkModeMq = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
-		const colorscheme = darkModeMq && darkModeMq.matches && 'green' || 'light';
-		body.classList.remove( 'colorscheme-light', 'colorscheme-green', 'colorscheme-auto' );
+		const darkModeMq =
+			window.matchMedia &&
+			window.matchMedia( '(prefers-color-scheme: dark)' );
+		const colorscheme =
+			( darkModeMq && darkModeMq.matches && 'green' ) || 'light';
+		body.classList.remove( 'colorscheme-light', 'colorscheme-green' );
 		body.classList.add( `colorscheme-${ colorscheme }` );
 	};
 
 	const initAutoDark = () => {
 		updateAutoDark();
-		const darkModeMq = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
-		if (darkModeMq) {
-			darkModeMq.addEventListener('change', event => { updateAutoDark(); } );
+		const darkModeMq =
+			window.matchMedia &&
+			window.matchMedia( '(prefers-color-scheme: dark)' );
+		if ( darkModeMq ) {
+			darkModeMq.addEventListener( 'change', updateAutoDark );
 		}
 	};
 

--- a/assets/js/auto-dark-switcher.js
+++ b/assets/js/auto-dark-switcher.js
@@ -1,0 +1,27 @@
+/* --------------------------------------------------------------
+   Sunflower – Automatisch dunkles Design
+   -------------------------------------------------------------- */
+( () => {
+
+	const updateAutoDark = () => {
+		const body = document.body;
+		const darkModeMq = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
+		const colorscheme = darkModeMq && darkModeMq.matches && 'green' || 'light';
+		body.classList.remove( 'colorscheme-light', 'colorscheme-green', 'colorscheme-auto' );
+		body.classList.add( `colorscheme-${ colorscheme }` );
+	};
+
+	const initAutoDark = () => {
+		updateAutoDark();
+		const darkModeMq = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
+		if (darkModeMq) {
+			darkModeMq.addEventListener('change', event => { updateAutoDark(); } );
+		}
+	};
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', initAutoDark );
+	} else {
+		initAutoDark();
+	}
+} )();

--- a/assets/js/design-switcher.js
+++ b/assets/js/design-switcher.js
@@ -21,6 +21,15 @@
 
 	const applyClasses = ( { formstyle, colorscheme, footer } ) => {
 		const body = document.body;
+		let trueColorscheme = colorscheme;
+		if ( colorscheme === 'auto' ) {
+			const darkModeMql =
+				window.matchMedia &&
+				window.matchMedia( '(prefers-color-scheme: dark)' );
+			trueColorscheme =
+				( darkModeMql && darkModeMql.matches && 'green' ) || 'light';
+		}
+
 		body.classList.remove(
 			'formstyle-rounded',
 			'formstyle-sharp',
@@ -30,7 +39,7 @@
 			'footer-green'
 		);
 		body.classList.add( `formstyle-${ formstyle }` );
-		body.classList.add( `colorscheme-${ colorscheme }` );
+		body.classList.add( `colorscheme-${ trueColorscheme }` );
 		body.classList.add( `footer-${ footer }` );
 	};
 

--- a/footer.php
+++ b/footer.php
@@ -121,17 +121,26 @@ $sunflower_social_media_profiles = sunflower_get_social_media_profiles();
 						$sunflower_options      = get_option( 'sunflower_options' );
 						$sunflower_color_scheme = $sunflower_options['sunflower_color_scheme'] ?? 'green';
 
-						if ( 'light' === $sunflower_color_scheme ) {
-							$sunflower_logo_path = 'assets/img/logo-diegruenen.svg';
+						if ( 'auto' === $sunflower_color_scheme ) {
+							printf(
+								'<picture><source srcset="%s" media="(prefers-color-scheme: dark)"><img src="%s" class="img-fluid default-logo" alt="%s"></picture>',
+								esc_url( sunflower_parent_or_child( 'assets/img/logo-diegruenen-auf-tanne.svg' ) ),
+								esc_url( sunflower_parent_or_child( 'assets/img/logo-diegruenen.svg' ) ),
+								esc_attr( 'Logo BÜNDNIS 90/DIE GRÜNEN' )
+							);
 						} else {
-							$sunflower_logo_path = 'assets/img/logo-diegruenen-auf-tanne.svg';
-						}
+							if ( 'light' === $sunflower_color_scheme ) {
+								$sunflower_logo_path = 'assets/img/logo-diegruenen.svg';
+							} else {
+								$sunflower_logo_path = 'assets/img/logo-diegruenen-auf-tanne.svg';
+							}
 
-						printf(
-							'<img src="%s" class="img-fluid default-logo" alt="%s">',
-							esc_url( sunflower_parent_or_child( $sunflower_logo_path ) ),
-							esc_attr( 'Logo BÜNDNIS 90/DIE GRÜNEN' )
-						);
+							printf(
+								'<img src="%s" class="img-fluid default-logo" alt="%s">',
+								esc_url( sunflower_parent_or_child( $sunflower_logo_path ) ),
+								esc_attr( 'Logo BÜNDNIS 90/DIE GRÜNEN' )
+							);
+						}
 					}
 
 					sunflower_inline_svg( 'assets/img/concave.svg' );

--- a/functions/options/class-sunflowersettingspage.php
+++ b/functions/options/class-sunflowersettingspage.php
@@ -370,6 +370,7 @@ class SunflowerSettingsPage {
 		$options = array(
 			array( 'light', __( 'Light', 'sunflower' ) ),
 			array( 'green', __( 'Dark', 'sunflower' ) ),
+			array( 'auto', __( 'Auto', 'sunflower' ) ),
 		);
 		foreach ( $options as $option ) {
 			$selected = ( isset( $this->options['sunflower_color_scheme'] ) && $this->options['sunflower_color_scheme'] === $option[0] ) ? 'selected' : '';

--- a/functions/s.php
+++ b/functions/s.php
@@ -139,6 +139,16 @@ function sunflower_scripts() {
 		);
 	}
 
+	if ( $sunflower_options['sunflower_color_scheme'] == 'auto' ) {
+		wp_enqueue_script(
+			'auto-dark-switcher',
+			get_template_directory_uri() . '/assets/js/auto-dark-switcher.js',
+			null,
+			SUNFLOWER_VERSION,
+			true
+		);
+	}
+
 	wp_localize_script(
 		'sunflower-admin-media',
 		'texts',

--- a/functions/s.php
+++ b/functions/s.php
@@ -139,7 +139,7 @@ function sunflower_scripts() {
 		);
 	}
 
-	if ( $sunflower_options['sunflower_color_scheme'] == 'auto' ) {
+	if ( 'auto' === $sunflower_options['sunflower_color_scheme'] || ! empty( $sunflower_options['sunflower_design_switcher'] ) ) {
 		wp_enqueue_script(
 			'auto-dark-switcher',
 			get_template_directory_uri() . '/assets/js/auto-dark-switcher.js',

--- a/functions/theme.php
+++ b/functions/theme.php
@@ -222,7 +222,11 @@ function sunflower_get_body_classes() {
 	}
 
 	if ( ! empty( $options['sunflower_color_scheme'] ) ) {
-		$classes[] = 'colorscheme-' . sanitize_html_class( $options['sunflower_color_scheme'] );
+		if ( $options['sunflower_color_scheme'] == 'auto' ) {
+			$classes[] = 'colorscheme-light';
+		} else {
+			$classes[] = 'colorscheme-' . sanitize_html_class( $options['sunflower_color_scheme'] );
+		}
 	}
 
 	if ( ! empty( $options['sunflower_footer_layout'] ) ) {

--- a/functions/theme.php
+++ b/functions/theme.php
@@ -222,7 +222,7 @@ function sunflower_get_body_classes() {
 	}
 
 	if ( ! empty( $options['sunflower_color_scheme'] ) ) {
-		if ( $options['sunflower_color_scheme'] == 'auto' ) {
+		if ( 'auto' === $options['sunflower_color_scheme'] ) {
 			$classes[] = 'colorscheme-light';
 		} else {
 			$classes[] = 'colorscheme-' . sanitize_html_class( $options['sunflower_color_scheme'] );

--- a/sass/_footer.scss
+++ b/sass/_footer.scss
@@ -60,7 +60,10 @@
                 opacity: 1 !important;
                 pointer-events: all !important;
 
-                picture { display: block }
+                picture {
+                    display: block;
+                }
+
                 img {
                     max-height: 120px;
                     min-height: 100px;

--- a/sass/_footer.scss
+++ b/sass/_footer.scss
@@ -60,6 +60,7 @@
                 opacity: 1 !important;
                 pointer-events: all !important;
 
+                picture { display: block }
                 img {
                     max-height: 120px;
                     min-height: 100px;

--- a/template-parts/header-standard.php
+++ b/template-parts/header-standard.php
@@ -71,6 +71,7 @@ if ( ( $sunflower_options['sunflower_design_switcher'] ?? false ) === 'checked' 
 			<select id="colorscheme-select">
 				<option value="light"><?php esc_html_e( 'Light', 'sunflower' ); ?></option>
 				<option value="green"><?php esc_html_e( 'Dark', 'sunflower' ); ?></option>
+				<option value="auto"><?php esc_html_e( 'Auto', 'sunflower' ); ?></option>
 			</select>
 		</label>
 


### PR DESCRIPTION
This is a minimal implementation of an automatic dark color mode. It adds a third colorscheme option "auto". In "auto" mode, the colorscheme is choosen as either "light" or "green" based on the CSS prefers-color-scheme media feature.

The documentation of the new feature is still missing (to be added if the feature is approved).

The implementation uses javascript instead of css media queries, because the latter would (probably) require more changes in the code. This implementation with javscript has no effect unless as the "auto" colorscheme is explicitly selected.

See #801.