### PR TITLE
Fix #1383: decode HTML entities in calendar event titles

### DIFF
--- a/functions/events.php
+++ b/functions/events.php
@@ -838,7 +838,10 @@ function sunflower_ajax_get_calendar_events() {
 		$event_tag_slugs = is_array( $event_tag_slugs ) ? $event_tag_slugs : array();
 
 		$calendar_event = array(
-			'title'         => get_post()->post_title,
+			// The calendar renders titles as plain text (textContent), so decode the
+			// HTML entities WordPress stores in post_title (e.g. block-editor "&amp;")
+			// back to plain characters. Inverse of WP's title encoding.
+			'title'         => wp_specialchars_decode( get_post()->post_title, ENT_QUOTES ),
 			'start'         => $fc_start,
 			'url'           => get_permalink(),
 			'allDay'        => $is_all_day,


### PR DESCRIPTION
Manually created events store their title HTML-encoded in post_title (e.g. "&amp;"), and the calendar renders titles as plain text (textContent), so the entity was shown literally. Decode the title in the AJAX handler with wp_specialchars_decode(). Imported events are unaffected since their titles are stored unencoded.