### PR TITLE
Replace hero cover concave corners with CSS mask-image approach for dark mode compatibility

### DIFF
--- a/sass/_header.scss
+++ b/sass/_header.scss
@@ -709,7 +709,7 @@ header .social-media-profiles {
         }
 
         .concave-30px {
-            color: map.get($custom-colors, "white");
+            display: none;
         }
 
         span {
@@ -735,28 +735,6 @@ header .social-media-profiles {
             &:nth-of-type(3) {
                 top: 44px;
                 left: 12px;
-            }
-        }
-
-        .concave-30px:nth-of-type(1) {
-            position: absolute;
-            left: -30px;
-            top: 10px;
-
-            @include media-breakpoint-down(xl) {
-                top: 5.5px;
-                left: -20px;
-            }
-        }
-
-        .concave-30px:nth-of-type(2) {
-            position: absolute;
-            top: 54.2px;
-            right: 20px;
-
-            @include media-breakpoint-down(xl) {
-                top: 57.2px;
-                right: 12px;
             }
         }
     }
@@ -788,19 +766,11 @@ header .social-media-profiles {
 
 body.admin-bar {
 
-    .stuck .right-bar,
-    .hamburger {
+    .top-bar.stuck {
 
-        top: 46px;
-
-        // WordPress Admin Bar has breakpoint at 783px.
-        @media (min-width: 783px) {
+        .right-bar {
             top: 32px;
         }
-    }
-
-    .stuck .right-bar.unfold {
-        top: 0;
     }
 
     &.hamburger-menu {
@@ -812,6 +782,29 @@ body.admin-bar {
                 .logo-background,
                 .custom-logo-link {
                     top: calc(46px - 115px);
+                }
+            }
+        }
+
+        .hamburger,
+        .right-bar.unfold {
+
+            top: 46px;
+
+            // WordPress Admin Bar has breakpoint at 783px.
+            @media (min-width: 783px) {
+                top: 32px;
+            }
+        }
+
+        .stuck {
+
+            .hamburger,
+            .right-bar.unfold {
+                // WordPress Admin Bar disappears when scrolling down up to
+                // 600px width, so we need to reset the top position to 0.
+                @media (max-width: 600px) {
+                    top: 0;
                 }
             }
         }

--- a/sass/_themes.scss
+++ b/sass/_themes.scss
@@ -43,7 +43,6 @@ $themes: (
         form-section-border: map.get($custom-colors, "klee"),
         form-section-title-color: map.get($custom-colors, "white"),
         form-section-title-background: map.get($custom-colors, "klee"),
-        cover-concave-img: "#{$sunflower-img-path}/concave-30px.svg",
         topmenu-color: map.get($custom-colors, "tanne"),
         topmenu-color-hover: map.get($custom-colors, "klee"),
         menu-dropdown-icon: "#{$sunflower-img-path}/dropdown.svg"
@@ -88,7 +87,6 @@ $themes: (
         form-section-border: map.get($custom-colors, "white"),
         form-section-title-color: map.get($custom-colors, "white"),
         form-section-title-background: map.get($custom-colors, "himmel"),
-        cover-concave-img: "#{$sunflower-img-path}/concave-30px_darkmode.svg",
         topmenu-color: map.get($custom-colors, "klee"),
         topmenu-color-hover: map.get($custom-colors, "white"),
         menu-dropdown-icon: "#{$sunflower-img-path}/dropdown_darkmode.svg"

--- a/sass/editor.scss
+++ b/sass/editor.scss
@@ -186,36 +186,47 @@ $fa-font-path: "#{$sunflower-vndr-path}/@fortawesome/fontawesome-free/webfonts";
         }
     }
 
-    // Pseudo-elements (concave SVG) – light theme default
-    &::before {
-        content: url("#{$sunflower-img-path}/concave-30px.svg");
-        height: 30px;
-        width: 38.16px;
+    $concave-svg: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 38.156677'%3E%3Cpath d='M0,0v10c15.948975,0,28.985107,12.447388,29.938171,28.156677h.061829V0H0Z'/%3E%3C/svg%3E";
+
+    // Pseudo-elements (concave shape via mask)
+    &::before,
+    &::after {
+        content: "";
+        background-color: map.get($custom-colors, "weiss");
+        -webkit-mask-image: url($concave-svg);
+        -webkit-mask-size: 100% 100%;
+        -webkit-mask-repeat: no-repeat;
+        mask-image: url($concave-svg);
+        mask-size: 100% 100%;
+        mask-repeat: no-repeat;
         position: absolute;
+    }
+
+    &::before {
+        width: 30px;
+        height: 38.16px;
         transform: rotate(-180deg);
         top: -17px;
         left: -1px;
 
         @media (max-width: 768px) {
-            height: 20px;
-            width: 25.44px;
+            width: 20px;
+            height: 25.44px;
             top: -11px;
             left: -1px;
         }
     }
 
     &::after {
-        content: url("#{$sunflower-img-path}/concave-30px.svg");
-        height: 30px;
-        width: 38.16px;
-        position: absolute;
+        width: 30px;
+        height: 38.16px;
         transform: rotate(180deg);
         bottom: -13px;
         right: -38px;
 
         @media (max-width: 768px) {
-            height: 20px;
-            width: 25.44px;
+            width: 20px;
+            height: 25.44px;
             top: -22px;
             right: -11px;
             bottom: auto;
@@ -228,12 +239,9 @@ $fa-font-path: "#{$sunflower-vndr-path}/@fortawesome/fontawesome-free/webfonts";
 .editor-styles-wrapper .colorscheme-green .wp-block-cover.is-style-sunflower-hero .wp-block-cover__inner-container {
     background-color: map.get($custom-colors, "schwarzwald");
 
-    &::before {
-        content: url("#{$sunflower-img-path}/concave-30px_darkmode.svg");
-    }
-
+    &::before,
     &::after {
-        content: url("#{$sunflower-img-path}/concave-30px_darkmode.svg");
+        background-color: map.get($custom-colors, "schwarzwald");
     }
 }
 

--- a/sass/wp-blocks/cover.scss
+++ b/sass/wp-blocks/cover.scss
@@ -36,21 +36,31 @@
     height: 100%;
 }
 
+$concave-svg: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 38.156677'%3E%3Cpath d='M0,0v10c15.948975,0,28.985107,12.447388,29.938171,28.156677h.061829V0H0Z'/%3E%3C/svg%3E";
+
 @mixin concave-pseudo(
     $primary-pos,
     $secondary-pos,
     $rotate,
     $size: 30px,
-    $offset-x: -1px,
-    $offset-y: -17px
+    $offset-x:0,
+    $offset-y: -28px
 ) {
+    content: "";
 
     @include themed-colorscheme-nested() {
-        content: url(#{t(cover-concave-img)});
+        background-color: t(background);
     }
 
-    height: $size;
-    width: $size * 1.272;
+    -webkit-mask-image: url($concave-svg);
+    -webkit-mask-size: 100% 100%;
+    -webkit-mask-repeat: no-repeat;
+    mask-image: url($concave-svg);
+    mask-size: 100% 100%;
+    mask-repeat: no-repeat;
+
+    width: $size;
+    height: $size * 1.272;
     position: absolute;
     transform: rotate($rotate);
 
@@ -58,10 +68,10 @@
     #{$secondary-pos}: $offset-x;
 
     @include breakpoint-down(md) {
-        height: 20px;
-        width: 20px * 1.272;
-        #{$primary-pos}: -11px;
-        #{$secondary-pos}: -1px;
+        height: 40px;
+        width: 40px * 1.272;
+        #{$primary-pos}: -30px;
+        #{$secondary-pos}: -10px;
     }
 }
 
@@ -306,13 +316,8 @@ body main #content .wp-block-cover:not(.is-style-sunflower-hero):has(.wp-block-c
 
         &::after {
 
-            @include concave-pseudo(bottom, right, 180deg, 30px, -37px, -13px);
+            @include concave-pseudo(bottom, right, 180deg, 30px, -29px, -10px);
 
-            @include breakpoint-down(md) {
-                top: -22px;
-                right: -11px;
-                transform: rotate(90deg);
-            }
         }
     }
 
@@ -437,6 +442,48 @@ body main #content .wp-block-cover:not(.is-style-sunflower-hero):has(.wp-block-c
 
     @include media-breakpoint-down(md) {
         margin: var(--grid-margin) 0 calc(var(--gap-large) * 2) 0 !important;
+    }
+}
+
+// -- Hamburger concave corners on hero (scroll with content) --
+
+body.hamburger-menu .entry-content > .wp-block-cover.is-style-sunflower-hero:first-child {
+
+    &::before,
+    &::after {
+        content: "";
+        background-color: map.get($custom-colors, "white");
+        -webkit-mask-image: url($concave-svg);
+        -webkit-mask-size: 100% 100%;
+        -webkit-mask-repeat: no-repeat;
+        mask-image: url($concave-svg);
+        mask-size: 100% 100%;
+        mask-repeat: no-repeat;
+        position: absolute;
+        z-index: 10;
+        width: 22px;
+        height: calc(22px * 1.272);
+    }
+
+    // Left of hamburger
+    &::before {
+        right: 62px;
+        top: calc(4.5px - var(--grid-margin));
+    }
+
+    // Below hamburger
+    &::after {
+        right: -1px;
+        top: calc(56.5px - var(--grid-margin));
+    }
+
+}
+
+body.hamburger-menu.colorscheme-green .entry-content > .wp-block-cover.is-style-sunflower-hero:first-child {
+
+    &::before,
+    &::after {
+        background-color: map.get($custom-colors, "schwarzwald");
     }
 }
 


### PR DESCRIPTION
* Replace hero cover concave corners with CSS mask-image approach for dark mode compatibility
* move hamburger concave decorations from fixed button to hero block so they scroll with content
* fix hamburger menu position with admin-bar active (logged in)